### PR TITLE
removed hardcoded namespace from agent service account

### DIFF
--- a/charts/site24x7agent/templates/site24x7-agent.yaml
+++ b/charts/site24x7agent/templates/site24x7-agent.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: site24x7
-  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: {{ .Values.apiversion }}


### PR DESCRIPTION
Hardcoded namespace in agent service account prevented the agents from starting properly if installed in non default namespace.