### PR TITLE
adding nodeselector

### DIFF
--- a/charts/site24x7agent/templates/site24x7-kube-state-metrics.yaml
+++ b/charts/site24x7agent/templates/site24x7-kube-state-metrics.yaml
@@ -59,6 +59,13 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
+      nodeSelector:
+        kubernetes.io/os: linux
+      {{- with .Values.nodeSelector}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+
 ---
     
 apiVersion: {{ .Values.apiversion }}

--- a/charts/site24x7agent/values.yaml
+++ b/charts/site24x7agent/values.yaml
@@ -10,3 +10,4 @@ kubernetes:
   kube_state_metrics_url: ""
   kube_api_server_endpoint_url: ""
   namespace: default
+nodeSelector: {}


### PR DESCRIPTION
Adding node selector for kube-state-metrics as this need to run on a linux node. If you have Windows nodes this will try to start on the Windows node. 